### PR TITLE
[Feature] 타이머가 울렸을 때 background사람들을 위한 LocalNotification 전달

### DIFF
--- a/iOS/Projects/App/MealGok/MealGok.entitlements
+++ b/iOS/Projects/App/MealGok/MealGok.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/iOS/Projects/App/MealGok/Project.swift
+++ b/iOS/Projects/App/MealGok/Project.swift
@@ -7,7 +7,7 @@ let project = Project.makeModule(
   name: ProjectEnvironment.default.appName,
   targets: .app(
     name: ProjectEnvironment.default.appName,
-    entitlements: nil,
+    entitlements: .file(path: .relativeToApp("MealGok/MealGok.entitlements")),
     dependencies: [
       .designSystem,
       .routerFactory,

--- a/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
+++ b/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
@@ -3,6 +3,8 @@ import SharedNotificationName
 import UIKit
 import UserNotifications
 
+// MARK: - AppDelegate
+
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -30,8 +32,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     return changeOrientation ? [.all] : [.portrait]
   }
 }
+
 private extension AppDelegate {
-  
   func addAppDelegateObserver() {
     NotificationCenter.default.addObserver(forName: .portraitScreenMode, object: nil, queue: .main) { _ in
       self.changeOrientation = false

--- a/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
+++ b/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
@@ -1,11 +1,19 @@
 import DesignSystem
 import SharedNotificationName
 import UIKit
+import UserNotifications
 
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     addAppDelegateObserver()
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+      if granted {
+        DispatchQueue.main.async {
+          UIApplication.shared.registerForRemoteNotifications()
+        }
+      }
+    }
     return true
   }
 
@@ -21,7 +29,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_: UIApplication, supportedInterfaceOrientationsFor _: UIWindow?) -> UIInterfaceOrientationMask {
     return changeOrientation ? [.all] : [.portrait]
   }
-
+}
+private extension AppDelegate {
+  
   func addAppDelegateObserver() {
     NotificationCenter.default.addObserver(forName: .portraitScreenMode, object: nil, queue: .main) { _ in
       self.changeOrientation = false

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -8,11 +8,12 @@
 
 import Foundation
 import UserNotifications
+import OSLog
 
 // MARK: - TimerLocalNotificationUseCaseRepresentable
 
 protocol TimerLocalNotificationUseCaseRepresentable {
-  func addChallengeCompleteNotification(identifier notificationIdentifier: String, completion: @escaping (Error?) -> Void)
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String)
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String)
 }
 
@@ -27,16 +28,20 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
 
   private var currentUserNotificationCenter = UNUserNotificationCenter.current()
 
-  func addChallengeCompleteNotification(identifier notificationIdentifier: String, completion: @escaping (Error?) -> Void) {
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String) {
     let content = UNMutableNotificationContent()
     content.title = "Lunch time"
     content.body = "Food is cooked... let's eat!"
 
-    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
 
     let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
-
-    currentUserNotificationCenter.add(request, withCompletionHandler: completion)
+    UNUserNotificationCenter.current().add(request) { error in
+      if let error {
+        Logger().error("\(error.localizedDescription)")
+      }
+      
+    }
   }
 
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -21,30 +21,44 @@ protocol TimerLocalNotificationUseCaseRepresentable {
 
 final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable {
   private let timeInterval: Double
+  private let notificationContent: NotificationContent
 
-  init(minutes: Int, seconds: Int = 0) {
+  init(minutes: Int, seconds: Int = 0, notificationContent: NotificationContent = .init()) {
     timeInterval = Double(minutes * 60) + Double(seconds)
+    self.notificationContent = notificationContent
   }
 
   private var currentUserNotificationCenter = UNUserNotificationCenter.current()
 
   func addChallengeCompleteNotification(identifier notificationIdentifier: String) {
     let content = UNMutableNotificationContent()
-    content.title = "Lunch time"
-    content.body = "Food is cooked... let's eat!"
+    content.title = notificationContent.notificationContentTitle
+    content.body = notificationContent.notificationContentBody
 
-    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
 
     let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
     UNUserNotificationCenter.current().add(request) { error in
       if let error {
         Logger().error("\(error.localizedDescription)")
       }
-      
     }
   }
 
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {
     currentUserNotificationCenter.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
+  }
+}
+
+struct NotificationContent {
+  let notificationContentTitle: String
+  let notificationContentBody: String
+  
+  init(
+    notificationContentTitle: String = "목표한 시간동안 식사를 하셨습니다!",
+    notificationContentBody: String = "식사를 기록하고, 공유하는 것은 어떨까요?"
+  ) {
+    self.notificationContentTitle = notificationContentTitle
+    self.notificationContentBody = notificationContentBody
   }
 }

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -12,15 +12,22 @@ import UserNotifications
 // MARK: - TimerLocalNotificationUseCaseRepresentable
 
 protocol TimerLocalNotificationUseCaseRepresentable {
-  func addChallengeCompleteNotification(identifier notificationIdentifier: String, timeInterval: Double)
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String, completion: @escaping (Error?) -> Void)
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String)
 }
 
 // MARK: - TimerLocalNotificationUseCase
 
 final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable {
+  private let timeInterval: Double
+
+  init(minutes: Int, seconds: Int = 0) {
+    timeInterval = Double(minutes * 60) + Double(seconds)
+  }
+
   private var currentUserNotificationCenter = UNUserNotificationCenter.current()
-  func addChallengeCompleteNotification(identifier notificationIdentifier: String, timeInterval: Double) {
+
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String, completion: @escaping (Error?) -> Void) {
     let content = UNMutableNotificationContent()
     content.title = "Lunch time"
     content.body = "Food is cooked... let's eat!"
@@ -29,8 +36,7 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
 
     let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
 
-    currentUserNotificationCenter.add(request) { _ in
-    }
+    currentUserNotificationCenter.add(request, withCompletionHandler: completion)
   }
 
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
-import UserNotifications
 import OSLog
+import UserNotifications
 
 // MARK: - TimerLocalNotificationUseCaseRepresentable
 
@@ -31,10 +31,7 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
   private var currentUserNotificationCenter = UNUserNotificationCenter.current()
 
   func addChallengeCompleteNotification(identifier notificationIdentifier: String) {
-    let content = UNMutableNotificationContent()
-    content.title = notificationContent.notificationContentTitle
-    content.body = notificationContent.notificationContentBody
-
+    let content = makeNotificationContent()
     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
 
     let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
@@ -48,12 +45,23 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {
     currentUserNotificationCenter.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
   }
+  
+  private func makeNotificationContent() -> UNMutableNotificationContent {
+    let content = UNMutableNotificationContent()
+    content.title = notificationContent.notificationContentTitle
+    content.body = notificationContent.notificationContentBody
+    content.sound = .default
+    
+    return content
+  }
 }
+
+// MARK: - NotificationContent
 
 struct NotificationContent {
   let notificationContentTitle: String
   let notificationContentBody: String
-  
+
   init(
     notificationContentTitle: String = "목표한 시간동안 식사를 하셨습니다!",
     notificationContentBody: String = "식사를 기록하고, 공유하는 것은 어떨까요?"

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  TimerLocalNotificationUseCase.swift
+//  MealTimerFeature
+//
+//  Created by MaraMincho on 2/19/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - TimerLocalNotificationUseCaseRepresentable
+
+protocol TimerLocalNotificationUseCaseRepresentable {
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String, timeInterval: Double)
+  func removeChallengeCompleteNotification(identifier notificationIdentifier: String)
+}
+
+// MARK: - TimerLocalNotificationUseCase
+
+final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable {
+  private var currentUserNotificationCenter = UNUserNotificationCenter.current()
+  func addChallengeCompleteNotification(identifier notificationIdentifier: String, timeInterval: Double) {
+    let content = UNMutableNotificationContent()
+    content.title = "Lunch time"
+    content.body = "Food is cooked... let's eat!"
+
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+
+    let request = UNNotificationRequest(identifier: notificationIdentifier, content: content, trigger: trigger)
+
+    currentUserNotificationCenter.add(request) { _ in
+    }
+  }
+
+  func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {
+    currentUserNotificationCenter.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
+  }
+}

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -26,6 +26,7 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   private var oneSecondsTimer = Timer.publish(every: 1, on: .main, in: .common)
 
   private var startTime: Date
+  private let notificationIdentifier = UUID()
   private let isFinishPublisher: CurrentValueSubject<Bool, Never> = .init(false)
 
   private let customStringFormatter: CustomTimeStringFormatter
@@ -43,6 +44,13 @@ final class TimerUseCase: TimerUseCasesRepresentable {
     self.repository = repository
     self.startTime = startTime
     self.timerLocalNotificationUseCase = timerLocalNotificationUseCase
+  }
+
+  private func addCompleteNotification() {
+    let completion: (Error?) -> Void = { [weak self] _ in
+      self?.isFinishPublisher.send(true)
+    }
+    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier.uuidString, completion: completion)
   }
 
   func imageDataURL() -> URL? {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -44,13 +44,12 @@ final class TimerUseCase: TimerUseCasesRepresentable {
     self.repository = repository
     self.startTime = startTime
     self.timerLocalNotificationUseCase = timerLocalNotificationUseCase
+
+    addCompleteNotification()
   }
 
   private func addCompleteNotification() {
-    let completion: (Error?) -> Void = { [weak self] _ in
-      self?.isFinishPublisher.send(true)
-    }
-    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier.uuidString, completion: completion)
+    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier.uuidString)
   }
 
   func imageDataURL() -> URL? {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -29,13 +29,20 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   private let isFinishPublisher: CurrentValueSubject<Bool, Never> = .init(false)
 
   private let customStringFormatter: CustomTimeStringFormatter
+  private let timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable
 
   private let repository: SaveMealGokChalengeRepositoryRepresentable?
 
-  init(startTime: Date, customStringFormatter: CustomTimeStringFormatter, repository: SaveMealGokChalengeRepositoryRepresentable?) {
+  init(
+    startTime: Date,
+    customStringFormatter: CustomTimeStringFormatter,
+    timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable,
+    repository: SaveMealGokChalengeRepositoryRepresentable?
+  ) {
     self.customStringFormatter = customStringFormatter
     self.repository = repository
     self.startTime = startTime
+    self.timerLocalNotificationUseCase = timerLocalNotificationUseCase
   }
 
   func imageDataURL() -> URL? {

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/View/TimerSceneViewController.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/View/TimerSceneViewController.swift
@@ -16,8 +16,6 @@ import UIKit
 final class TimerSceneViewController: UIViewController {
   // MARK: Properties
 
-  private let viewDidAppearPublisher: PassthroughSubject<Void, Never> = .init()
-
   private let generator = UINotificationFeedbackGenerator()
 
   private let viewModel: TimerSceneViewModelRepresentable
@@ -64,7 +62,6 @@ final class TimerSceneViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     generator.notificationOccurred(.success)
-    viewDidAppearPublisher.send()
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -102,7 +99,6 @@ private extension TimerSceneViewController {
 
   func bind() {
     let output = viewModel.transform(input: .init(
-      viewDidAppear: viewDidAppearPublisher.eraseToAnyPublisher(),
       didTapCompleteButton: timerView.publisher(gesture: .tap).eraseToAnyPublisher().map { _ in return }.eraseToAnyPublisher(),
       showAlertPublisher: timerView.publisher(gesture: .longPress).eraseToAnyPublisher().map { _ in return }.eraseToAnyPublisher(),
       didCancelChallenge: cancelButtonDidTapPublisher.eraseToAnyPublisher()

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/TimerSceneViewModel.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/TimerSceneViewModel.swift
@@ -13,7 +13,6 @@ import RouterFactory
 // MARK: - TimerSceneViewModelInput
 
 public struct TimerSceneViewModelInput {
-  let viewDidAppear: AnyPublisher<Void, Never>
   let didTapCompleteButton: AnyPublisher<Void, Never>
   let showAlertPublisher: AnyPublisher<Void, Never>
   let didCancelChallenge: AnyPublisher<Void, Never>
@@ -56,12 +55,6 @@ final class TimerSceneViewModel {
 extension TimerSceneViewModel: TimerSceneViewModelRepresentable {
   public func transform(input: TimerSceneViewModelInput) -> TimerSceneViewModelOutput {
     subscriptions.removeAll()
-
-    input.viewDidAppear
-      .sink { [timerUseCase] in
-        timerUseCase.start()
-      }
-      .store(in: &subscriptions)
 
     let updateTimerLabelText: TimerSceneViewModelOutput = timerUseCase
       .timerLabelText()

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -35,10 +35,8 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
 
-//    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-//    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
-    let customStringFormatter = CustomTimeStringFormatter(minutes: 0, seconds: 10)
-    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: 0, seconds: 10)
+    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
+    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
     let timerUseCase = TimerUseCase(
       startTime: startTime,
       customStringFormatter: customStringFormatter,

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -34,14 +34,15 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
 
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
-    
+
     let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase()
+    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes)
     let timerUseCase = TimerUseCase(
       startTime: startTime,
       customStringFormatter: customStringFormatter,
       timerLocalNotificationUseCase: timerLocalNotificationUseCase,
-      repository: repository)
+      repository: repository
+    )
 
     let viewModel = TimerSceneViewModel(timerUseCase: timerUseCase)
     viewModel.router = self

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -35,8 +35,10 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
 
-    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes)
+//    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
+//    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
+    let customStringFormatter = CustomTimeStringFormatter(minutes: 0, seconds: 10)
+    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: 0, seconds: 10)
     let timerUseCase = TimerUseCase(
       startTime: startTime,
       customStringFormatter: customStringFormatter,

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -34,8 +34,14 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
 
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
+    
     let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-    let timerUseCase = TimerUseCase(startTime: startTime, customStringFormatter: customStringFormatter, repository: repository)
+    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase()
+    let timerUseCase = TimerUseCase(
+      startTime: startTime,
+      customStringFormatter: customStringFormatter,
+      timerLocalNotificationUseCase: timerLocalNotificationUseCase,
+      repository: repository)
 
     let viewModel = TimerSceneViewModel(timerUseCase: timerUseCase)
     viewModel.router = self


### PR DESCRIPTION
add Notification의 Completion은 Notification을 클릭했을 때가 아닌, Notification을 추가했을 때 즉각적으로 실행된다.
ChatGPT
add(_:withCompletionHandler:) 메서드는 UNUserNotificationCenter 객체에게 알림 요청(UNNotificationRequest)을 추가하고 처리 완료를 알려주는 역할을 합니다. 이 메서드는 알림을 예약하거나 즉시 보내는 데 사용될 수 있습니다.

이 메서드는 주어진 알림 요청을 사용자의 알림 센터에 추가합니다. 알림이 예약되거나 전송되면 completionHandler가 호출되어 작업의 성공 또는 실패 여부를 알려줍니다. completionHandler가 제공되지 않으면 작업의 성공 또는 실패에 대한 정보를 알 수 없습니다. completionHandler에는 에러가 발생한 경우 해당 에러가 전달됩니다.

close : #87


레퍼런스
https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649508-add