### PR TITLE
[Feature] 유저 종료 시나리오 구성

### DIFF
--- a/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
+++ b/iOS/Projects/App/MealGok/Sources/Application/AppDelegate.swift
@@ -12,7 +12,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     addAppDelegateObserver()
-    requestNotificationAuth()
     return true
   }
 
@@ -37,37 +36,5 @@ private extension AppDelegate {
     NotificationCenter.default.addObserver(forName: .allScreenMode, object: nil, queue: .main) { _ in
       self.changeOrientation = true
     }
-  }
-}
-
-// MARK: UNUserNotificationCenterDelegate
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
-  func requestNotificationAuth() {
-    let authOptions = UNAuthorizationOptions(arrayLiteral: .alert, .badge, .sound)
-
-    UNUserNotificationCenter
-      .current()
-      .requestAuthorization(options: authOptions) { _, error in
-        if let error {
-          Logger().debug("\(#function) \(error.localizedDescription)")
-        }
-      }
-  }
-
-  func userNotificationCenter(
-    _: UNUserNotificationCenter,
-    didReceive _: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Void
-  ) {
-    _ = completionHandler()
-  }
-
-  func userNotificationCenter(
-    _: UNUserNotificationCenter,
-    willPresent _: UNNotification,
-    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-  ) {
-    completionHandler([.list, .sound, .banner, .badge])
   }
 }

--- a/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokPushNotificationManager.swift
+++ b/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokPushNotificationManager.swift
@@ -1,0 +1,58 @@
+//
+//  MealGokPushNotificationManager.swift
+//  MealGok
+//
+//  Created by MaraMincho on 2/19/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import OSLog
+import UIKit
+import UserNotifications
+
+// MARK: - MealGokPushNotificationManager
+
+final class MealGokPushNotificationManager: UINavigationController {
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    UNUserNotificationCenter.current().delegate = self
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("cant use this method")
+  }
+}
+
+// MARK: UNUserNotificationCenterDelegate
+
+extension MealGokPushNotificationManager: UNUserNotificationCenterDelegate {
+  func requestNotificationAuth() {
+    let authOptions = UNAuthorizationOptions(arrayLiteral: .alert, .badge, .sound)
+
+    UNUserNotificationCenter
+      .current()
+      .requestAuthorization(options: authOptions) { _, error in
+        if let error {
+          Logger().debug("\(#function) \(error.localizedDescription)")
+        }
+      }
+  }
+
+  func userNotificationCenter(_: UNUserNotificationCenter, didReceive _: UNNotificationResponse) async {
+    guard
+      let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+      let rootViewController = windowScene.windows.first?.rootViewController
+    else {
+      return
+    }
+    let vc = UIViewController()
+    vc.view.backgroundColor = .blue
+    rootViewController.present(vc, animated: true)
+    return
+  }
+
+  func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification) async -> UNNotificationPresentationOptions {
+    return [.badge, .sound, .badge, .banner]
+  }
+}

--- a/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokPushNotificationManager.swift
+++ b/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokPushNotificationManager.swift
@@ -39,18 +39,7 @@ extension MealGokPushNotificationManager: UNUserNotificationCenterDelegate {
       }
   }
 
-  func userNotificationCenter(_: UNUserNotificationCenter, didReceive _: UNNotificationResponse) async {
-    guard
-      let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-      let rootViewController = windowScene.windows.first?.rootViewController
-    else {
-      return
-    }
-    let vc = UIViewController()
-    vc.view.backgroundColor = .blue
-    rootViewController.present(vc, animated: true)
-    return
-  }
+  func userNotificationCenter(_: UNUserNotificationCenter, didReceive _: UNNotificationResponse) async {}
 
   func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification) async -> UNNotificationPresentationOptions {
     return [.badge, .sound, .badge, .banner]

--- a/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokRouterFactory.swift
+++ b/iOS/Projects/App/MealGok/Sources/RouterFactory/MealGokRouterFactory.swift
@@ -41,7 +41,7 @@ final class MealGokRouterFactory: RouterFactoriable {
   }
 
   func build() -> UIViewController {
-    let navigationController = UINavigationController()
+    let navigationController = MealGokPushNotificationManager()
     navigationController.navigationBar.isHidden = true
     return navigationController
   }

--- a/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
@@ -12,22 +12,30 @@ import Foundation
 struct PrevChallengeManagerRepository: PrevChallengeManageable {
   private let startDateKey: String
   private let totalSecondsKey: String
+  private let imageURLKey: String
   private let userDefaults = UserDefaults.standard
 
   init(
     startDateKey: String = Constants.startDateKey,
-    totalSecondsKey: String = Constants.totalSecondsKey
+    totalSecondsKey: String = Constants.totalSecondsKey,
+    imageURLKey: String = Constants.imageURLKey
   ) {
     self.startDateKey = startDateKey
     self.totalSecondsKey = totalSecondsKey
+    self.imageURLKey = imageURLKey
   }
 
   func prevChallengeStartDate() -> Date? {
     return userDefaults.date(forKey: startDateKey)
   }
 
-  func prevChallengeTotalSeconds() -> Int {
-    return userDefaults.integer(forKey: totalSecondsKey)
+  func prevChallengeTotalSeconds() -> Int? {
+    let totalSeconds = userDefaults.integer(forKey: totalSecondsKey)
+    return totalSeconds == 0 ? nil : totalSeconds
+  }
+
+  func prevChallengeURL() -> URL? {
+    return userDefaults.url(forKey: imageURLKey)
   }
 
   func setPrevChallengeStartDate(_ date: Date) {
@@ -38,8 +46,13 @@ struct PrevChallengeManagerRepository: PrevChallengeManageable {
     userDefaults.set(value, forKey: totalSecondsKey)
   }
 
+  func setPrevChallengeImageURL(_ value: URL?) {
+    userDefaults.set(value, forKey: imageURLKey)
+  }
+
   private enum Constants {
     static let startDateKey: String = "ChallengeStartDate"
     static let totalSecondsKey: String = "TargetTime"
+    static let imageURLKey: String = "ImageURLKey"
   }
 }

--- a/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
@@ -1,0 +1,45 @@
+//
+//  PrevChallengeManagerRepository.swift
+//  MealTimerFeature
+//
+//  Created by MaraMincho on 2/20/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+import CommonExtensions
+
+struct PrevChallengeManagerRepository: PrevChallengeUserDefaultsManager {
+  private let startDateKey: String
+  private let totalSecondsKey: String
+  private let userDefaults = UserDefaults.standard
+  
+  init(
+    startDateKey: String = Constants.startDateKey,
+    totalSecondsKey: String = Constants.totalSecondsKey
+  ) {
+    self.startDateKey = startDateKey
+    self.totalSecondsKey = totalSecondsKey
+  }
+  
+  func prevChallengeStartDate() -> Date? {
+    return userDefaults.date(forKey: startDateKey)
+  }
+  
+  func prevChallengeTotalSeconds() -> Int {
+    return userDefaults.integer(forKey: totalSecondsKey)
+  }
+  
+  func setPrevChallengeStartDate(_ date: Date) {
+    userDefaults.set(date: date, forKey: startDateKey)
+  }
+  
+  func setPrevChallengeTotalSeconds(_ value: Int){
+    userDefaults.set(value, forKey: totalSecondsKey)
+  }
+  
+  private enum Constants {
+    static let startDateKey: String = "ChallengeStartDate"
+    static let totalSecondsKey: String = "TargetTime"
+  }
+}

--- a/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
@@ -6,14 +6,14 @@
 //  Copyright © 2024 com.maramincho. All rights reserved.
 //
 
-import Foundation
 import CommonExtensions
+import Foundation
 
-struct PrevChallengeManagerRepository: PrevChallengeManager {
+struct PrevChallengeManagerRepository: PrevChallengeManageable {
   private let startDateKey: String
   private let totalSecondsKey: String
   private let userDefaults = UserDefaults.standard
-  
+
   init(
     startDateKey: String = Constants.startDateKey,
     totalSecondsKey: String = Constants.totalSecondsKey
@@ -21,23 +21,23 @@ struct PrevChallengeManagerRepository: PrevChallengeManager {
     self.startDateKey = startDateKey
     self.totalSecondsKey = totalSecondsKey
   }
-  
+
   func prevChallengeStartDate() -> Date? {
     return userDefaults.date(forKey: startDateKey)
   }
-  
+
   func prevChallengeTotalSeconds() -> Int {
     return userDefaults.integer(forKey: totalSecondsKey)
   }
-  
+
   func setPrevChallengeStartDate(_ date: Date) {
     userDefaults.set(date: date, forKey: startDateKey)
   }
-  
-  func setPrevChallengeTotalSeconds(_ value: Int){
+
+  func setPrevChallengeTotalSeconds(_ value: Int) {
     userDefaults.set(value, forKey: totalSecondsKey)
   }
-  
+
   private enum Constants {
     static let startDateKey: String = "ChallengeStartDate"
     static let totalSecondsKey: String = "TargetTime"

--- a/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CommonExtensions
 
-struct PrevChallengeManagerRepository: PrevChallengeUserDefaultsManager {
+struct PrevChallengeManagerRepository: PrevChallengeManager {
   private let startDateKey: String
   private let totalSecondsKey: String
   private let userDefaults = UserDefaults.standard

--- a/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/PrevChallengeManagerRepository.swift
@@ -12,17 +12,14 @@ import Foundation
 struct PrevChallengeManagerRepository: PrevChallengeManageable {
   private let startDateKey: String
   private let totalSecondsKey: String
-  private let imageURLKey: String
   private let userDefaults = UserDefaults.standard
 
   init(
     startDateKey: String = Constants.startDateKey,
-    totalSecondsKey: String = Constants.totalSecondsKey,
-    imageURLKey: String = Constants.imageURLKey
+    totalSecondsKey: String = Constants.totalSecondsKey
   ) {
     self.startDateKey = startDateKey
     self.totalSecondsKey = totalSecondsKey
-    self.imageURLKey = imageURLKey
   }
 
   func prevChallengeStartDate() -> Date? {
@@ -34,10 +31,6 @@ struct PrevChallengeManagerRepository: PrevChallengeManageable {
     return totalSeconds == 0 ? nil : totalSeconds
   }
 
-  func prevChallengeURL() -> URL? {
-    return userDefaults.url(forKey: imageURLKey)
-  }
-
   func setPrevChallengeStartDate(_ date: Date) {
     userDefaults.set(date: date, forKey: startDateKey)
   }
@@ -46,13 +39,8 @@ struct PrevChallengeManagerRepository: PrevChallengeManageable {
     userDefaults.set(value, forKey: totalSecondsKey)
   }
 
-  func setPrevChallengeImageURL(_ value: URL?) {
-    userDefaults.set(value, forKey: imageURLKey)
-  }
-
   private enum Constants {
     static let startDateKey: String = "ChallengeStartDate"
     static let totalSecondsKey: String = "TargetTime"
-    static let imageURLKey: String = "ImageURLKey"
   }
 }

--- a/iOS/Projects/Features/MealTimer/Sources/Data/SaveMealGokChallengeRepository.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Data/SaveMealGokChallengeRepository.swift
@@ -1,5 +1,5 @@
 //
-//  SaveMealGokChalengeRepository.swift
+//  SaveMealGokChallengeRepository.swift
 //  MealTimerFeature
 //
 //  Created by MaraMincho on 2/7/24.
@@ -11,9 +11,9 @@ import OSLog
 import RealmSwift
 import ThirdParty
 
-// MARK: - SaveMealGokChalengeRepository
+// MARK: - SaveMealGokChallengeRepository
 
-final class SaveMealGokChalengeRepository: PersistableRepository, SaveMealGokChalengeRepositoryRepresentable {
+final class SaveMealGokChallengeRepository: PersistableRepository, SaveMealGokChalengeRepositoryRepresentable {
   func save(mealGokChallengeDTO dto: MealGokChallengeDTO) throws {
     let persistableObject = dto.adaptPersistableObject()
     try realm.write {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
@@ -13,7 +13,6 @@ import Foundation
 protocol PrevChallengeLoadManageable {
   func prevChallengeStartDate() -> Date?
   func prevChallengeTotalSeconds() -> Int?
-  func prevChallengeURL() -> URL?
 }
 
 // MARK: - PrevChallengeWriteManageable
@@ -21,7 +20,6 @@ protocol PrevChallengeLoadManageable {
 protocol PrevChallengeWriteManageable {
   func setPrevChallengeStartDate(_ date: Date)
   func setPrevChallengeTotalSeconds(_ value: Int)
-  func setPrevChallengeImageURL(_ value: URL?)
 }
 
 typealias PrevChallengeManageable = PrevChallengeLoadManageable & PrevChallengeWriteManageable

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
@@ -1,5 +1,5 @@
 //
-//  PrevChallengeManagerRepositoryRepresentable.swift
+//  PrevChallengeManagerable.swift
 //  MealTimerFeature
 //
 //  Created by MaraMincho on 2/20/24.
@@ -8,14 +8,18 @@
 
 import Foundation
 
-protocol PrevChallengeLoadManager {
+// MARK: - PrevChallengeLoadManager
+
+protocol PrevChallengeLoadManageable {
   func prevChallengeStartDate() -> Date?
   func prevChallengeTotalSeconds() -> Int
 }
 
-protocol PrevChallengeWriteManager {
+// MARK: - PrevChallengeWriteManager
+
+protocol PrevChallengeWriteManageable {
   func setPrevChallengeStartDate(_ date: Date)
   func setPrevChallengeTotalSeconds(_ value: Int)
 }
 
-typealias PrevChallengeManager = PrevChallengeWriteManager & PrevChallengeLoadManager
+typealias PrevChallengeManageable = PrevChallengeLoadManageable & PrevChallengeWriteManageable

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManageable.swift
@@ -1,5 +1,5 @@
 //
-//  PrevChallengeManagerable.swift
+//  PrevChallengeManageable.swift
 //  MealTimerFeature
 //
 //  Created by MaraMincho on 2/20/24.
@@ -8,18 +8,20 @@
 
 import Foundation
 
-// MARK: - PrevChallengeLoadManager
+// MARK: - PrevChallengeLoadManageable
 
 protocol PrevChallengeLoadManageable {
   func prevChallengeStartDate() -> Date?
-  func prevChallengeTotalSeconds() -> Int
+  func prevChallengeTotalSeconds() -> Int?
+  func prevChallengeURL() -> URL?
 }
 
-// MARK: - PrevChallengeWriteManager
+// MARK: - PrevChallengeWriteManageable
 
 protocol PrevChallengeWriteManageable {
   func setPrevChallengeStartDate(_ date: Date)
   func setPrevChallengeTotalSeconds(_ value: Int)
+  func setPrevChallengeImageURL(_ value: URL?)
 }
 
 typealias PrevChallengeManageable = PrevChallengeLoadManageable & PrevChallengeWriteManageable

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManagerRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManagerRepositoryRepresentable.swift
@@ -1,0 +1,16 @@
+//
+//  PrevChallengeManagerRepositoryRepresentable.swift
+//  MealTimerFeature
+//
+//  Created by MaraMincho on 2/20/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+
+protocol PrevChallengeUserDefaultsManager {
+  func prevChallengeStartDate() -> Date?
+  func prevChallengeTotalSeconds() -> Int
+  func setPrevChallengeStartDate(_ date: Date)
+  func setPrevChallengeTotalSeconds(_ value: Int)
+}

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManagerRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/Entity/PrevChallengeManagerRepositoryRepresentable.swift
@@ -8,9 +8,14 @@
 
 import Foundation
 
-protocol PrevChallengeUserDefaultsManager {
+protocol PrevChallengeLoadManager {
   func prevChallengeStartDate() -> Date?
   func prevChallengeTotalSeconds() -> Int
+}
+
+protocol PrevChallengeWriteManager {
   func setPrevChallengeStartDate(_ date: Date)
   func setPrevChallengeTotalSeconds(_ value: Int)
 }
+
+typealias PrevChallengeManager = PrevChallengeWriteManager & PrevChallengeLoadManager

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeLoadUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeLoadUseCase.swift
@@ -1,0 +1,54 @@
+//
+//  PrevChallengeLoadUseCase.swift
+//  MealTimerFeature
+//
+//  Created by MaraMincho on 2/20/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - PrevChallengeLoadUseCaseRepresentable
+
+protocol PrevChallengeLoadUseCaseRepresentable {
+  func checkPrevChallenge() -> PrevChallengeSupportState
+}
+
+// MARK: - PrevChallengeLoadUseCase
+
+final class PrevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable {
+  let loader: PrevChallengeManageable
+
+  init(loader: PrevChallengeManageable) {
+    self.loader = loader
+  }
+
+  func checkPrevChallenge() -> PrevChallengeSupportState {
+    guard
+      let startDate = loader.prevChallengeStartDate(),
+      let totalSeconds = loader.prevChallengeTotalSeconds()
+    else {
+      return .idle
+    }
+    let now = Date.now
+    let prevFinishDate = startDate.addingTimeInterval(Double(totalSeconds))
+    let subtractValue = now.timeIntervalSince(prevFinishDate)
+
+    if subtractValue < 0 { // 아직 챌린지가 끝나지 않았다면
+      let prevChallengeURL = loader.prevChallengeURL()
+      return .timer(totalSeconds: totalSeconds, prevImageURL: prevChallengeURL)
+    } else if subtractValue < 600 { // 챌린지가 끝났고, 10분 이내라면
+      return .successChallenge
+    } else { // 10분이 넘어 버린 경우
+      return .idle
+    }
+  }
+}
+
+// MARK: - PrevChallengeSupportState
+
+enum PrevChallengeSupportState {
+  case timer(totalSeconds: Int, prevImageURL: URL?)
+  case successChallenge
+  case idle
+}

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeLoadUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeLoadUseCase.swift
@@ -35,10 +35,11 @@ final class PrevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable {
     let subtractValue = now.timeIntervalSince(prevFinishDate)
 
     if subtractValue < 0 { // 아직 챌린지가 끝나지 않았다면
-      let prevChallengeURL = loader.prevChallengeURL()
-      return .timer(totalSeconds: totalSeconds, prevImageURL: prevChallengeURL)
+      let targetMinutes = totalSeconds / 60
+      return .timer(targetMinutes: targetMinutes, startDate: startDate)
     } else if subtractValue < 600 { // 챌린지가 끝났고, 10분 이내라면
-      return .successChallenge
+      let targetMinutes = totalSeconds / 60
+      return .successChallenge(targetMinutes: targetMinutes, startDate: startDate)
     } else { // 10분이 넘어 버린 경우
       return .idle
     }
@@ -48,7 +49,7 @@ final class PrevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable {
 // MARK: - PrevChallengeSupportState
 
 enum PrevChallengeSupportState {
-  case timer(totalSeconds: Int, prevImageURL: URL?)
-  case successChallenge
+  case timer(targetMinutes: Int, startDate: Date)
+  case successChallenge(targetMinutes: Int, startDate: Date)
   case idle
 }

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeSaveUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/PrevChallengeSaveUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  PrevChallengeSaveUseCase.swift
+//  MealTimerFeature
+//
+//  Created by MaraMincho on 2/20/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - PrevChallengeWriteUseCaseRepresentable
+
+protocol PrevChallengeWriteUseCaseRepresentable {
+  func setPrevChallengeStartDate(_ date: Date)
+  func setPrevChallengeTotalSeconds(_ value: Int)
+}
+
+// MARK: - PrevChallengeWriteUseCase
+
+final class PrevChallengeWriteUseCase: PrevChallengeWriteUseCaseRepresentable {
+  let prevChallengeWriteRepository: PrevChallengeWriteManageable
+  init(prevChallengeWriteRepository: PrevChallengeWriteManageable) {
+    self.prevChallengeWriteRepository = prevChallengeWriteRepository
+  }
+
+  func setPrevChallengeStartDate(_ date: Date) {
+    prevChallengeWriteRepository.setPrevChallengeStartDate(date)
+  }
+
+  func setPrevChallengeTotalSeconds(_ value: Int) {
+    prevChallengeWriteRepository.setPrevChallengeTotalSeconds(value)
+  }
+}

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -51,7 +51,6 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
     content.title = notificationContent.notificationContentTitle
     content.body = notificationContent.notificationContentBody
     content.sound = .default
-    content.userInfo["MealGokChallenge"] = "HelloWorld"
 
     return content
   }

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerLocalNotificationUseCase.swift
@@ -45,13 +45,14 @@ final class TimerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresen
   func removeChallengeCompleteNotification(identifier notificationIdentifier: String) {
     currentUserNotificationCenter.removePendingNotificationRequests(withIdentifiers: [notificationIdentifier])
   }
-  
+
   private func makeNotificationContent() -> UNMutableNotificationContent {
     let content = UNMutableNotificationContent()
     content.title = notificationContent.notificationContentTitle
     content.body = notificationContent.notificationContentBody
     content.sound = .default
-    
+    content.userInfo["MealGokChallenge"] = "HelloWorld"
+
     return content
   }
 }

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -30,14 +30,14 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   private let isFinishPublisher: CurrentValueSubject<Bool, Never> = .init(false)
 
   private let customStringFormatter: CustomTimeStringFormatter
-  private let timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable
+  private let timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable?
 
   private let repository: SaveMealGokChalengeRepositoryRepresentable?
 
   init(
     startTime: Date,
     customStringFormatter: CustomTimeStringFormatter,
-    timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable,
+    timerLocalNotificationUseCase: TimerLocalNotificationUseCaseRepresentable?,
     repository: SaveMealGokChalengeRepositoryRepresentable?
   ) {
     self.customStringFormatter = customStringFormatter
@@ -49,8 +49,8 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   }
 
   private func addCompleteNotification() {
-    timerLocalNotificationUseCase.removeChallengeCompleteNotification(identifier: notificationIdentifier)
-    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier)
+    timerLocalNotificationUseCase?.removeChallengeCompleteNotification(identifier: notificationIdentifier)
+    timerLocalNotificationUseCase?.addChallengeCompleteNotification(identifier: notificationIdentifier)
   }
 
   /// 시작시간을 통해서 imageDataURL을 리턴합니다.

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -26,7 +26,7 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   private var oneSecondsTimer = Timer.publish(every: 1, on: .main, in: .common)
 
   private var startTime: Date
-  private let notificationIdentifier = UUID()
+  private let notificationIdentifier = "MealGokChallengeLocalNotificationIdentifier"
   private let isFinishPublisher: CurrentValueSubject<Bool, Never> = .init(false)
 
   private let customStringFormatter: CustomTimeStringFormatter
@@ -49,7 +49,8 @@ final class TimerUseCase: TimerUseCasesRepresentable {
   }
 
   private func addCompleteNotification() {
-    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier.uuidString)
+    timerLocalNotificationUseCase.removeChallengeCompleteNotification(identifier: notificationIdentifier)
+    timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier)
   }
 
   func imageDataURL() -> URL? {

--- a/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Domain/UseCases/TimerUseCase.swift
@@ -53,6 +53,7 @@ final class TimerUseCase: TimerUseCasesRepresentable {
     timerLocalNotificationUseCase.addChallengeCompleteNotification(identifier: notificationIdentifier)
   }
 
+  /// 시작시간을 통해서 imageDataURL을 리턴합니다.
   func imageDataURL() -> URL? {
     let dateFormatter: DateFormatter = {
       let dateFormatter = DateFormatter()

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/View/MealGokHomeViewController.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/View/MealGokHomeViewController.swift
@@ -30,6 +30,7 @@ final class MealGokHomeViewController: UIViewController {
   private let needUpdateTargetTimeSubject: PassthroughSubject<Void, Never> = .init()
   private let saveTargetTimeSubject: PassthroughSubject<Int, Never> = .init()
   private let startTimerSubject: PassthroughSubject<Data?, Never> = .init()
+  private let viewDidAppearPublisher: PassthroughSubject<Void, Never> = .init()
   @Published private var targetTime: Int = 20
 
   // MARK: UI Components
@@ -193,6 +194,7 @@ final class MealGokHomeViewController: UIViewController {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     contentScrollView.contentSize = contentScrollViewContentSize
+    viewDidAppearPublisher.send()
   }
 }
 
@@ -271,7 +273,8 @@ private extension MealGokHomeViewController {
       didCameraButtonTouchPublisher: cameraButton.publisher(event: .touchUpInside).map { _ in return }.eraseToAnyPublisher(),
       startTimeScenePublisher: startTimerSubject.eraseToAnyPublisher(),
       needUpdateTargetTimePublisher: needUpdateTargetTimeSubject.eraseToAnyPublisher(),
-      saveTargetTimePublisher: saveTargetTimeSubject.eraseToAnyPublisher()
+      saveTargetTimePublisher: saveTargetTimeSubject.eraseToAnyPublisher(),
+      viewDidAppearPublisher: viewDidAppearPublisher.eraseToAnyPublisher()
     ))
 
     $targetTime.sink { [weak self] targetTime in

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
@@ -17,6 +17,7 @@ public struct MealGokHomeViewModelInput {
   let startTimeScenePublisher: AnyPublisher<Data?, Never>
   let needUpdateTargetTimePublisher: AnyPublisher<Void, Never>
   let saveTargetTimePublisher: AnyPublisher<Int, Never>
+  let viewDidLoadPublisher: AnyPublisher<Void, Never>
 }
 
 public typealias MealGokHomeViewModelOutput = AnyPublisher<MealGokHomeState, Never>
@@ -44,10 +45,16 @@ final class MealGokHomeViewModel {
   weak var router: MealGokHomeFactoriable?
   private let targetTimeUseCase: TargetTimeUseCaseRepresentable
   private let savePhotoUseCase: SavePhotoUseCaseRepresentable
+  private let prevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable
 
-  init(targetTimeUseCase: TargetTimeUseCaseRepresentable, savePhotoUseCase: SavePhotoUseCaseRepresentable) {
+  init(
+    targetTimeUseCase: TargetTimeUseCaseRepresentable,
+    savePhotoUseCase: SavePhotoUseCaseRepresentable,
+    prevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable
+  ) {
     self.targetTimeUseCase = targetTimeUseCase
     self.savePhotoUseCase = savePhotoUseCase
+    self.prevChallengeLoadUseCase = prevChallengeLoadUseCase
   }
 }
 
@@ -56,6 +63,20 @@ final class MealGokHomeViewModel {
 extension MealGokHomeViewModel: MealTimerSceneViewModelRepresentable {
   public func transform(input: MealGokHomeViewModelInput) -> MealGokHomeViewModelOutput {
     subscriptions.removeAll()
+    
+    input.viewDidLoadPublisher
+      .sink { [prevChallengeLoadUseCase, router] _ in
+        let state = prevChallengeLoadUseCase.checkPrevChallenge()
+        switch state {
+        case let .timer(totalSeconds, prevImageURL):
+          <#code#>
+        case .successChallenge:
+          <#code#>
+        case .idle:
+          break
+        }
+      }
+      .store(in: &subscriptions)
 
     input.startTimeScenePublisher
       .sink { [targetTimeUseCase, router, savePhotoUseCase] data in

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
@@ -63,15 +63,15 @@ final class MealGokHomeViewModel {
 extension MealGokHomeViewModel: MealTimerSceneViewModelRepresentable {
   public func transform(input: MealGokHomeViewModelInput) -> MealGokHomeViewModelOutput {
     subscriptions.removeAll()
-    
+
     input.viewDidLoadPublisher
       .sink { [prevChallengeLoadUseCase, router] _ in
         let state = prevChallengeLoadUseCase.checkPrevChallenge()
         switch state {
-        case let .timer(totalSeconds, prevImageURL):
-          <#code#>
-        case .successChallenge:
-          <#code#>
+        case let .timer(targetMinutes, startDate):
+          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate)
+        case let .successChallenge(targetMinutes, startDate):
+          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate)
         case .idle:
           break
         }

--- a/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/Presentation/ViewModel/MealGokHomeViewModel.swift
@@ -17,7 +17,7 @@ public struct MealGokHomeViewModelInput {
   let startTimeScenePublisher: AnyPublisher<Data?, Never>
   let needUpdateTargetTimePublisher: AnyPublisher<Void, Never>
   let saveTargetTimePublisher: AnyPublisher<Int, Never>
-  let viewDidLoadPublisher: AnyPublisher<Void, Never>
+  let viewDidAppearPublisher: AnyPublisher<Void, Never>
 }
 
 public typealias MealGokHomeViewModelOutput = AnyPublisher<MealGokHomeState, Never>
@@ -46,15 +46,18 @@ final class MealGokHomeViewModel {
   private let targetTimeUseCase: TargetTimeUseCaseRepresentable
   private let savePhotoUseCase: SavePhotoUseCaseRepresentable
   private let prevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable
+  private let prevChallengeWriteUseCase: PrevChallengeWriteUseCaseRepresentable
 
   init(
     targetTimeUseCase: TargetTimeUseCaseRepresentable,
     savePhotoUseCase: SavePhotoUseCaseRepresentable,
-    prevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable
+    prevChallengeLoadUseCase: PrevChallengeLoadUseCaseRepresentable,
+    prevChallengeWriteUseCase: PrevChallengeWriteUseCaseRepresentable
   ) {
     self.targetTimeUseCase = targetTimeUseCase
     self.savePhotoUseCase = savePhotoUseCase
     self.prevChallengeLoadUseCase = prevChallengeLoadUseCase
+    self.prevChallengeWriteUseCase = prevChallengeWriteUseCase
   }
 }
 
@@ -64,14 +67,14 @@ extension MealGokHomeViewModel: MealTimerSceneViewModelRepresentable {
   public func transform(input: MealGokHomeViewModelInput) -> MealGokHomeViewModelOutput {
     subscriptions.removeAll()
 
-    input.viewDidLoadPublisher
+    input.viewDidAppearPublisher
       .sink { [prevChallengeLoadUseCase, router] _ in
         let state = prevChallengeLoadUseCase.checkPrevChallenge()
         switch state {
         case let .timer(targetMinutes, startDate):
-          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate)
+          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate, isLocalNotificationNeed: false)
         case let .successChallenge(targetMinutes, startDate):
-          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate)
+          router?.startMealTimerScene(targetMinute: targetMinutes, startTime: startDate, isLocalNotificationNeed: false)
         case .idle:
           break
         }
@@ -79,9 +82,12 @@ extension MealGokHomeViewModel: MealTimerSceneViewModelRepresentable {
       .store(in: &subscriptions)
 
     input.startTimeScenePublisher
-      .sink { [targetTimeUseCase, router, savePhotoUseCase] data in
-        let startTime = savePhotoUseCase.saveDataWithNowDescription(data)
-        router?.startMealTimerScene(targetMinute: targetTimeUseCase.targetTime(), startTime: startTime)
+      .sink { [targetTimeUseCase, router, savePhotoUseCase, prevChallengeWriteUseCase] data in
+        let startDate = savePhotoUseCase.saveDataWithNowDescription(data)
+        let targetMinute = targetTimeUseCase.targetTime()
+        prevChallengeWriteUseCase.setPrevChallengeStartDate(startDate)
+        prevChallengeWriteUseCase.setPrevChallengeTotalSeconds(targetMinute * 60)
+        router?.startMealTimerScene(targetMinute: targetMinute, startTime: startDate, isLocalNotificationNeed: true)
       }
       .store(in: &subscriptions)
 

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
@@ -12,7 +12,7 @@ import UIKit
 // MARK: - MealGokHomeFactoriable
 
 protocol MealGokHomeFactoriable: RouterFactoriable {
-  func startMealTimerScene(targetMinute: Int, startTime: Date)
+  func startMealTimerScene(targetMinute: Int, startTime: Date, isLocalNotificationNeed: Bool)
 }
 
 // MARK: - MealGokHomeRouterFactory
@@ -33,13 +33,15 @@ public final class MealGokHomeRouterFactory: RouterFactoriable {
     let targetTimeUseCase = TargetTimeUseCase(repository: repository)
     let savePhotoUseCase = SavePhotoUseCase()
 
-    let prevChallengeLoadRepository = PrevChallengeManagerRepository()
-    let prevChallengeLoadUseCase = PrevChallengeLoadUseCase(loader: prevChallengeLoadRepository)
+    let userDefaultsRepository = PrevChallengeManagerRepository()
+    let prevChallengeLoadUseCase = PrevChallengeLoadUseCase(loader: userDefaultsRepository)
+    let prevChallengeWriteUseCase = PrevChallengeWriteUseCase(prevChallengeWriteRepository: userDefaultsRepository)
 
     let viewModel = MealGokHomeViewModel(
       targetTimeUseCase: targetTimeUseCase,
       savePhotoUseCase: savePhotoUseCase,
-      prevChallengeLoadUseCase: prevChallengeLoadUseCase
+      prevChallengeLoadUseCase: prevChallengeLoadUseCase,
+      prevChallengeWriteUseCase: prevChallengeWriteUseCase
     )
     viewModel.router = self
     return MealGokHomeViewController(viewModel: viewModel)
@@ -54,12 +56,13 @@ public final class MealGokHomeRouterFactory: RouterFactoriable {
 // MARK: MealGokHomeFactoriable
 
 extension MealGokHomeRouterFactory: MealGokHomeFactoriable {
-  func startMealTimerScene(targetMinute: Int, startTime: Date) {
+  func startMealTimerScene(targetMinute: Int, startTime: Date, isLocalNotificationNeed: Bool = true) {
     let router = StartMealTimerSceneRouterFactory(
       startTime: startTime,
       parentRouter: self,
       navigationController: navigationController,
-      targetTimeOfMinutes: targetMinute
+      targetTimeOfMinutes: targetMinute,
+      isLocalNotificationNeed: isLocalNotificationNeed
     )
     childRouters.append(router)
     router.start(build: router.build())

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
@@ -32,7 +32,7 @@ public final class MealGokHomeRouterFactory: RouterFactoriable {
     let repository = TargetTimeRepository()
     let targetTimeUseCase = TargetTimeUseCase(repository: repository)
     let savePhotoUseCase = SavePhotoUseCase()
-    
+
     let prevChallengeLoadRepository = PrevChallengeManagerRepository()
     let prevChallengeLoadUseCase = PrevChallengeLoadUseCase(loader: prevChallengeLoadRepository)
 

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/MealGokHomeRouterFactory.swift
@@ -32,8 +32,15 @@ public final class MealGokHomeRouterFactory: RouterFactoriable {
     let repository = TargetTimeRepository()
     let targetTimeUseCase = TargetTimeUseCase(repository: repository)
     let savePhotoUseCase = SavePhotoUseCase()
+    
+    let prevChallengeLoadRepository = PrevChallengeManagerRepository()
+    let prevChallengeLoadUseCase = PrevChallengeLoadUseCase(loader: prevChallengeLoadRepository)
 
-    let viewModel = MealGokHomeViewModel(targetTimeUseCase: targetTimeUseCase, savePhotoUseCase: savePhotoUseCase)
+    let viewModel = MealGokHomeViewModel(
+      targetTimeUseCase: targetTimeUseCase,
+      savePhotoUseCase: savePhotoUseCase,
+      prevChallengeLoadUseCase: prevChallengeLoadUseCase
+    )
     viewModel.router = self
     return MealGokHomeViewController(viewModel: viewModel)
   }

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -34,7 +34,7 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   }
 
   func build() -> UIViewController {
-    let repository = SaveMealGokChalengeRepository()
+    let repository = SaveMealGokChallengeRepository()
 
 //    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: targetTimeOfSeconds)
 //    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: targetTimeOfSeconds)

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -26,6 +26,7 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   var startTime: Date
 
   private let targetTimeOfMinutes: Int
+  private let targetTimeOfSeconds: Int
 
   func start(build: UIViewController) {
     navigationController?.pushViewController(build, animated: false)
@@ -35,8 +36,8 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
 
-//    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-//    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
+//    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: targetTimeOfSeconds)
+//    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: targetTimeOfSeconds)
     // 테스트 코드
     let customStringFormatter = CustomTimeStringFormatter(minutes: 0, seconds: 10)
     let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: 0, seconds: 10)
@@ -54,11 +55,18 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
     return viewController
   }
 
-  init(startTime: Date, parentRouter: Routing?, navigationController: UINavigationController?, targetTimeOfMinutes: Int) {
+  init(
+    startTime: Date,
+    parentRouter: Routing?,
+    navigationController: UINavigationController?,
+    targetTimeOfMinutes: Int,
+    targetTimeOfSeconds: Int = 0
+  ) {
     self.startTime = startTime
     self.parentRouter = parentRouter
     self.navigationController = navigationController
     self.targetTimeOfMinutes = targetTimeOfMinutes
+    self.targetTimeOfSeconds = targetTimeOfSeconds
   }
 }
 

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -35,8 +35,11 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   func build() -> UIViewController {
     let repository = SaveMealGokChalengeRepository()
 
-    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
-    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
+//    let customStringFormatter = CustomTimeStringFormatter(minutes: targetTimeOfMinutes, seconds: 0)
+//    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: 0)
+    // 테스트 코드
+    let customStringFormatter = CustomTimeStringFormatter(minutes: 0, seconds: 10)
+    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: 0, seconds: 10)
     let timerUseCase = TimerUseCase(
       startTime: startTime,
       customStringFormatter: customStringFormatter,

--- a/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
+++ b/iOS/Projects/Features/MealTimer/Sources/RouterFactory/StartMealTimerSceneRouterFactory.swift
@@ -25,6 +25,7 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
   var childRouters: [Routing] = []
   var startTime: Date
 
+  private let isLocalNotificationNeed: Bool
   private let targetTimeOfMinutes: Int
   private let targetTimeOfSeconds: Int
 
@@ -40,7 +41,7 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
 //    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: targetTimeOfMinutes, seconds: targetTimeOfSeconds)
     // 테스트 코드
     let customStringFormatter = CustomTimeStringFormatter(minutes: 0, seconds: 10)
-    let timerLocalNotificationUseCase = TimerLocalNotificationUseCase(minutes: 0, seconds: 10)
+    let timerLocalNotificationUseCase = isLocalNotificationNeed ? TimerLocalNotificationUseCase(minutes: 0, seconds: 10) : nil
     let timerUseCase = TimerUseCase(
       startTime: startTime,
       customStringFormatter: customStringFormatter,
@@ -60,13 +61,15 @@ final class StartMealTimerSceneRouterFactory: RouterFactoriable {
     parentRouter: Routing?,
     navigationController: UINavigationController?,
     targetTimeOfMinutes: Int,
-    targetTimeOfSeconds: Int = 0
+    targetTimeOfSeconds: Int = 0,
+    isLocalNotificationNeed: Bool
   ) {
     self.startTime = startTime
     self.parentRouter = parentRouter
     self.navigationController = navigationController
     self.targetTimeOfMinutes = targetTimeOfMinutes
     self.targetTimeOfSeconds = targetTimeOfSeconds
+    self.isLocalNotificationNeed = isLocalNotificationNeed
   }
 }
 

--- a/iOS/Projects/Shared/CommonExtensions/Sources/UserDefaults+Date.swift
+++ b/iOS/Projects/Shared/CommonExtensions/Sources/UserDefaults+Date.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public extension UserDefaults {
-    func set(date: Date?, forKey key: String){
-        self.set(date, forKey: key)
-    }
-    
-    func date(forKey key: String) -> Date? {
-        return self.value(forKey: key) as? Date
-    }
+  func set(date: Date?, forKey key: String) {
+    set(date, forKey: key)
+  }
+
+  func date(forKey key: String) -> Date? {
+    return value(forKey: key) as? Date
+  }
 }

--- a/iOS/Projects/Shared/CommonExtensions/Sources/UserDefaults+Date.swift
+++ b/iOS/Projects/Shared/CommonExtensions/Sources/UserDefaults+Date.swift
@@ -1,0 +1,19 @@
+//
+//  UserDefaults+Date.swift
+//  CommonExtensions
+//
+//  Created by MaraMincho on 2/20/24.
+//  Copyright © 2024 com.maramincho. All rights reserved.
+//
+
+import Foundation
+
+public extension UserDefaults {
+    func set(date: Date?, forKey key: String){
+        self.set(date, forKey: key)
+    }
+    
+    func date(forKey key: String) -> Date? {
+        return self.value(forKey: key) as? Date
+    }
+}

--- a/iOS/Projects/Shared/ThirdParty/Sources/PersistableObjects/MealGokChallengePersistedObject.swift
+++ b/iOS/Projects/Shared/ThirdParty/Sources/PersistableObjects/MealGokChallengePersistedObject.swift
@@ -21,8 +21,8 @@ public final class MealGokChallengePersistedObject: Object {
 
   /// init MealGokChallengePersistedObject
   /// - Parameters:
-  ///   - challengeDate: Date String of challenge
-  ///   - startTime: Start date of challenge. startDate must be formatted "yyyy-MM-dd"
+  ///   - challengeDateString: Date String of challenge. "yyyy-MM-dd"
+  ///   - startTime: Start date of challenge.
   ///   - endTime: End date of challenge
   ///   - imageDataURLString: Image URL that user take food or something, if nil no picture
   ///   - isSuccess: wether success


### PR DESCRIPTION
#  PushNotificationDelegate  객체 AppDelegate-> CustomUINavigationController
AppDelegate에서 너무 많은 일을 한다고 판단. 또한, AppDelegate가 아닌 CustomUINavigationController또한 싱글톤 처럼 어플리케이션이 종료될 때 까지 삭제되지 않기 때문에 안전하다고 판단


<br/><br/><br/><br/><br/>


# 타이머 시간에 따라 유저가 어떻게 행동할지 분기 처리

![image](https://github.com/MaraMincho/MealGok/assets/103064352/c7aae920-edd1-4840-a658-58691e5dddf6)

비교할 값 = Date.now - (가장 최근 식사 챌린지 시간 + 유저의 목표 시간)

## 1. 비교할 값이 음수라면
챌린지 목표 종료 시간이 종료되지 않았기 때문에 챌린지 화면을 이동


### 2. 비교할 값이 양수이면서, 10분 이내라면
챌린지 목표 종료 후 약 10분 이내면, 챌린지 성공으로 치부. 따라서 챌린지 성공 화면으로 이동


### 3. 비교할 값이 양수이면서, 10분 초과라면
챌린지 목표 종료 후 약 10분 이후에 접속하면 그것은 실패로 치부 


close: #63 